### PR TITLE
Fixes to make code work with old and new DatabaseConnector

### DIFF
--- a/R/ConnectionHandler.R
+++ b/R/ConnectionHandler.R
@@ -42,7 +42,11 @@ ConnectionHandler <- R6::R6Class(
     #' @param loadConnection                Boolean option to load connection right away
     #' @param snakeCaseToCamelCase          (Optional) Boolean. return the results columns in camel case (default)
     initialize = function(connectionDetails, loadConnection = TRUE, snakeCaseToCamelCase = TRUE) {
-      checkmate::assertClass(connectionDetails, "connectionDetails")
+      if (is(connectionDetails, "connectionDetails")) {
+        checkmate::assertClass(connectionDetails, "connectionDetails")
+      } else {
+        checkmate::assertClass(connectionDetails, "ConnectionDetails")
+      }
       self$connectionDetails <- connectionDetails
       self$snakeCaseToCamelCase <- snakeCaseToCamelCase
       if (loadConnection) {

--- a/R/DataMigrationManager.R
+++ b/R/DataMigrationManager.R
@@ -79,7 +79,11 @@ DataMigrationManager <- R6::R6Class(
       checkmate::checkString(databaseSchema)
       checkmate::checkString(tablePrefix)
       checkmate::checkString(migrationPath)
-      checkmate::checkClass(connectionDetails, "connectionDetails")
+      if (is(connectionDetails, "connectionDetails")) {
+        checkmate::assertClass(connectionDetails, "connectionDetails")
+      } else {
+        checkmate::assertClass(connectionDetails, "ConnectionDetails")
+      }
 
       # Set required variables
       self$tablePrefix <- tablePrefix
@@ -102,8 +106,11 @@ DataMigrationManager <- R6::R6Class(
     #' Check if migration table is present in schema
     #' @return boolean
     migrationTableExists = function() {
-      tables <- DatabaseConnector::getTableNames(private$connectionHandler$getConnection(), self$databaseSchema)
-      return(toupper(paste0(self$tablePrefix, "migration")) %in% tables)
+      return(DatabaseConnector::existsTable(
+        connection = private$connectionHandler$getConnection(),
+        databaseSchema = self$databaseSchema,
+        tableName = paste0(self$tablePrefix, "migration")
+      ))
     },
 
     #' Get path of migrations


### PR DESCRIPTION
This fixes two issues related to the upcoming DatabaseConnector 6.0.0. 

With these (minor) changes, the code will run both on the old and the new version. I deliberately created this PR from the main branch, hoping this could be turned into a patch release, so DatabaseConnector 6.0.0 can be released shortly.